### PR TITLE
Fix how kwargs are handled with a request

### DIFF
--- a/tixte/http.py
+++ b/tixte/http.py
@@ -49,7 +49,7 @@ class HTTP:
         
     
     async def request(self, route: Route, **kwargs: Any) -> Dict:
-        async with self.session.request(route.method, route.url, {**route.parameters, **kwargs}) as resp:
+        async with self.session.request(route.method, route.url, **{**route.parameters, **kwargs}) as resp:
             if resp.status != 200:
                 raise NotImplementedError("API status was not 200, this hasn't been implemented yet.")
             

--- a/tixte/http.py
+++ b/tixte/http.py
@@ -49,11 +49,11 @@ class HTTP:
         
     
     async def request(self, route: Route, **kwargs: Any) -> Dict:
-        async with self.session.request(route.method, route.url, **{**route.parameters, **kwargs}) as resp:
+        kwargs = {**route.parameters, **kwargs}
+        async with self.session.request(route.method, route.url, **kwargs) as resp:
             if resp.status != 200:
                 raise NotImplementedError("API status was not 200, this hasn't been implemented yet.")
             
             # We're going to assume the API returns Dict for now.
             # We'll change this later as I get more info.
             return await resp.json()  
-        

--- a/tixte/http.py
+++ b/tixte/http.py
@@ -53,7 +53,5 @@ class HTTP:
         async with self.session.request(route.method, route.url, **kwargs) as resp:
             if resp.status != 200:
                 raise NotImplementedError("API status was not 200, this hasn't been implemented yet.")
-            
-            # We're going to assume the API returns Dict for now.
-            # We'll change this later as I get more info.
+
             return await resp.json()  


### PR DESCRIPTION
Kwargs would not get processed correctly, I've fixed it so they do.

Originally I had added two `**` to the big dict of kwargs, but I removed that and separated it into two lines... looks better.

Also removed the two comment lines at the bottom, not needed.

